### PR TITLE
Replace deprecated datetime.utcnow() with timezone-aware now()

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,5 +1,5 @@
 from flask import Flask, jsonify, request
-from datetime import datetime
+from datetime import datetime, timezone
 
 app = Flask(__name__)
 
@@ -18,7 +18,7 @@ def create_invoice():
         "amount": data.get("amount"),
         "currency": data.get("currency", "USD"),
         "status": "pending",
-        "created_at": datetime.utcnow().isoformat()
+        "created_at": datetime.now(timezone.utc).isoformat()
     }
     invoices.append(invoice)
     return jsonify(invoice), 201


### PR DESCRIPTION
`datetime.utcnow()` is deprecated since Python 3.12 — it returns a naive datetime even though the value represents UTC, which is the source of many timezone bugs. The drop-in replacement is `datetime.now(timezone.utc)`, which returns an aware datetime.

The serialized `created_at` field now includes a `+00:00` UTC offset suffix in its ISO 8601 representation. Any client that parses with `datetime.fromisoformat` (3.11+) handles both forms; clients doing exact string matching may need an update.